### PR TITLE
fix getAllCapabilities exception handling

### DIFF
--- a/android/src/main/kotlin/com/sstonn/flutter_wear_os_connectivity/FlutterWearOsConnectivityPlugin.kt
+++ b/android/src/main/kotlin/com/sstonn/flutter_wear_os_connectivity/FlutterWearOsConnectivityPlugin.kt
@@ -167,9 +167,7 @@ class FlutterWearOsConnectivityPlugin : FlutterPlugin, MethodCallHandler, Activi
                         }
                     } catch (e: Exception) {
                         scope(Dispatchers.Main).launch {
-                            result.success(
-                                result.success(emptyMap<String, Map<String, Any>>())
-                            )
+                            result.success(emptyMap<String, Map<String, Any>>())
                         }
                     }
                 }


### PR DESCRIPTION
the exception handler would through an exception because result.success is called inside of itself..

```
E/AndroidRuntime(13446): FATAL EXCEPTION: main
E/AndroidRuntime(13446): Process: com.shootformance.app.dev, PID: 13446
E/AndroidRuntime(13446): java.lang.IllegalArgumentException: Unsupported value: 'kotlin.Unit' of type 'class kotlin.Unit'
E/AndroidRuntime(13446): 	at io.flutter.plugin.common.StandardMessageCodec.writeValue(StandardMessageCodec.java:297)
E/AndroidRuntime(13446): 	at io.flutter.plugin.common.StandardMethodCodec.encodeSuccessEnvelope(StandardMethodCodec.java:61)
E/AndroidRuntime(13446): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:272)
E/AndroidRuntime(13446): 	at com.sstonn.flutter_wear_os_connectivity.FlutterWearOsConnectivityPlugin$onMethodCall$6$2.invokeSuspend(FlutterWearOsConnectivityPlugin.kt:187)
E/AndroidRuntime(13446): 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
E/AndroidRuntime(13446): 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
E/AndroidRuntime(13446): 	at android.os.Handler.handleCallback(Handler.java:958)
E/AndroidRuntime(13446): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime(13446): 	at android.os.Looper.loopOnce(Looper.java:205)
E/AndroidRuntime(13446): 	at android.os.Looper.loop(Looper.java:294)
E/AndroidRuntime(13446): 	at android.app.ActivityThread.main(ActivityThread.java:8177)
E/AndroidRuntime(13446): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(13446): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
E/AndroidRuntime(13446): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
E/AndroidRuntime(13446): 	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@4a48125, Dispatchers.Main]

```